### PR TITLE
GP-685 - error handling and username fixes

### DIFF
--- a/src/Omnipay/WorldpayCGHosted/Message/Notification.php
+++ b/src/Omnipay/WorldpayCGHosted/Message/Notification.php
@@ -44,7 +44,7 @@ class Notification extends AbstractResponse
         }
 
         $document = simplexml_import_dom($responseDom->documentElement);
-        $this->data = $document->notify->orderStatusEvent;
+        $this->data = $document->notify;
     }
 
     /**
@@ -62,7 +62,7 @@ class Notification extends AbstractResponse
             return null;
         }
 
-        return $this->data->payment->lastEvent->__toString();
+        return $this->getOrder()->payment->lastEvent->__toString();
     }
 
     /**
@@ -70,7 +70,7 @@ class Notification extends AbstractResponse
      */
     public function hasStatus()
     {
-        return !empty($this->data->payment->lastEvent);
+        return !empty($this->getOrder()->payment->lastEvent);
     }
 
     /**

--- a/src/Omnipay/WorldpayCGHosted/Message/PurchaseRequest.php
+++ b/src/Omnipay/WorldpayCGHosted/Message/PurchaseRequest.php
@@ -82,6 +82,27 @@ class PurchaseRequest extends AbstractRequest
     }
 
     /**
+     * Get the separate username if configured (more secure approach for basic auth) or fallback to merchant if not
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->parameters->get('username', $this->getParameter('merchant'));
+    }
+
+    /**
+     * Set basic auth username
+     *
+     * @param string $value
+     * @return AbstractRequest
+     */
+    public function setUsername($value)
+    {
+        return $this->setParameter('username', $value);
+    }
+
+    /**
      * Get pa response
      *
      * @return string

--- a/src/Omnipay/WorldpayCGHosted/Message/PurchaseRequest.php
+++ b/src/Omnipay/WorldpayCGHosted/Message/PurchaseRequest.php
@@ -298,7 +298,7 @@ class PurchaseRequest extends AbstractRequest
         $document->appendChild($node);
 
         $authorisation = base64_encode(
-            $this->getMerchant() . ':' . $this->getPassword()
+            $this->getUsername() . ':' . $this->getPassword()
         );
 
         $headers = [

--- a/src/Omnipay/WorldpayCGHosted/Message/RedirectResponse.php
+++ b/src/Omnipay/WorldpayCGHosted/Message/RedirectResponse.php
@@ -38,7 +38,7 @@ class RedirectResponse extends Response implements RedirectResponseInterface
      */
     public function getRedirectUrl()
     {
-        $url = $this->data->reference->__toString();
+        $url = $this->getOrder()->reference->__toString();
 
         // Custom result URLs available: http://bit.ly/2uRpuX0
         if (!empty($this->successUrl)) {

--- a/src/Omnipay/WorldpayCGHosted/Message/ResponseTrait.php
+++ b/src/Omnipay/WorldpayCGHosted/Message/ResponseTrait.php
@@ -5,8 +5,6 @@ namespace Omnipay\WorldpayCGHosted\Message;
 /**
  * Encapsulates response-like behaviour shared between actual Worldpay response objects and notifications, which
  * actually come in Worldpay-initiated requests.
- *
- * @method \SimpleXMLElement|null getData()
  */
 trait ResponseTrait
 {
@@ -28,11 +26,11 @@ trait ResponseTrait
      */
     public function getTransactionId()
     {
-        if (empty($this->getData())) {
+        if (empty($this->getOrder())) {
             return null;
         }
 
-        $attributes = $this->getData()->attributes();
+        $attributes = $this->getOrder()->attributes();
 
         if (isset($attributes['orderCode'])) {
             return $attributes['orderCode'];
@@ -48,12 +46,12 @@ trait ResponseTrait
      */
     public function isSuccessful()
     {
-        if (!isset($this->getData()->payment->lastEvent)) {
+        if (!isset($this->getOrder()->payment->lastEvent)) {
             return false;
         }
 
         return in_array(
-            strtoupper($this->getData()->payment->lastEvent),
+            strtoupper($this->getOrder()->payment->lastEvent),
             [
                 self::$PAYMENT_STATUS_AUTHORISED,
                 self::$PAYMENT_STATUS_CAPTURED,
@@ -70,12 +68,12 @@ trait ResponseTrait
      */
     public function isPending()
     {
-        if (!isset($this->getData()->payment->lastEvent)) {
+        if (!isset($this->getOrder()->payment->lastEvent)) {
             return false;
         }
 
         return in_array(
-            strtoupper($this->getData()->payment->lastEvent),
+            strtoupper($this->getOrder()->payment->lastEvent),
             [
                 self::$PAYMENT_STATUS_SENT_FOR_AUTHORISATION,
             ],
@@ -90,16 +88,29 @@ trait ResponseTrait
      */
     public function isCancelled()
     {
-        if (!isset($this->getData()->payment->lastEvent)) {
+        if (!isset($this->getOrder()->payment->lastEvent)) {
             return false;
         }
 
         return in_array(
-            strtoupper($this->getData()->payment->lastEvent),
+            strtoupper($this->getOrder()->payment->lastEvent),
             [
                 self::$PAYMENT_STATUS_CANCELLED,
             ],
             true
         );
+    }
+
+    public function getOrder()
+    {
+        if (isset($this->data->orderStatusEvent)) {
+            return $this->data->orderStatusEvent; // Notifications
+        }
+
+        if (isset($this->data->orderStatus)) {
+            return $this->data->orderStatus; // Order responses
+        }
+
+        return null;
     }
 }

--- a/tests/Omnipay/WorldpayCGHosted/Message/NotificationTest.php
+++ b/tests/Omnipay/WorldpayCGHosted/Message/NotificationTest.php
@@ -18,7 +18,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_VALID
         );
-        $notification->getData();
 
         $this->assertTrue($notification->isValid());
         $this->assertTrue($notification->isAuthorised());
@@ -39,7 +38,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_VALID
         );
-        $notification->getData();
 
         $this->assertTrue($notification->isValid());
         $this->assertFalse($notification->isAuthorised());
@@ -60,7 +58,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_BAD
         );
-        $notification->getData();
 
         $this->assertFalse($notification->isValid());
         $this->assertFalse($notification->isAuthorised());
@@ -81,7 +78,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             'not-a-real-ip'
         );
-        $notification->getData();
 
         $this->assertFalse($notification->isValid());
         $this->assertFalse($notification->isAuthorised());
@@ -102,7 +98,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             '' // no origin IP
         );
-        $notification->getData();
 
         $this->assertFalse($notification->isValid());
         $this->assertFalse($notification->isAuthorised());
@@ -126,7 +121,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_VALID
         );
-        $notification->getData();
 
         $this->assertTrue($notification->isValid());
         $this->assertTrue($notification->isAuthorised());
@@ -150,7 +144,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_VALID
         );
-        $notification->getData();
 
         $this->assertTrue($notification->isValid());
         $this->assertTrue($notification->isAuthorised());
@@ -171,7 +164,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_VALID
         );
-        $notification->getData();
 
         $this->assertTrue($notification->isValid());
         $this->assertFalse($notification->isAuthorised());
@@ -192,7 +184,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_VALID
         );
-        $notification->getData();
 
         $this->assertTrue($notification->isValid());
         $this->assertFalse($notification->isAuthorised());
@@ -213,7 +204,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_VALID
         );
-        $notification->getData();
 
         $this->assertTrue($notification->isValid());
         $this->assertFalse($notification->isAuthorised());
@@ -246,7 +236,6 @@ class NotificationTest extends TestCase
             $http->getBody(),
             self::ORIGIN_IP_VALID
         );
-        $notification->getData();
 
         $this->assertFalse($notification->isValid());
         $this->assertFalse($notification->isAuthorised());

--- a/tests/Omnipay/WorldpayCGHosted/Mock/PurchaseErrorDuplicateOrder.txt
+++ b/tests/Omnipay/WorldpayCGHosted/Mock/PurchaseErrorDuplicateOrder.txt
@@ -3,9 +3,9 @@ Connection: close
 Server: VPS-3.033.00
 Date: Sat, 23 Feb 2013 05:17:32 GMT
 Content-type: text/xml
-Content-length: 376
+Content-length: 341
 
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
                                 "http://dtd.worldpay.com/paymentService_v1.dtd">
-<paymentService version="1.4.1" merchantCode="MYMERCHANT"><reply><orderStatus orderCode="T0211234"><error>Nasty internal error!</error></orderStatus></reply></paymentService>
+<paymentService version="1.4" merchantCode="MYMERCHANT"><reply><error code="5"><![CDATA[Duplicate Order]]></error></reply></paymentService>

--- a/tests/Omnipay/WorldpayCGHosted/Mock/PurchaseErrorGeneric.txt
+++ b/tests/Omnipay/WorldpayCGHosted/Mock/PurchaseErrorGeneric.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Connection: close
+Server: VPS-3.033.00
+Date: Sat, 23 Feb 2013 05:17:32 GMT
+Content-type: text/xml
+Content-length: 376
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4.1" merchantCode="MYMERCHANT"><reply><error>Nasty internal error!</error></reply></paymentService>

--- a/tests/Omnipay/WorldpayCGHosted/Mock/PurchaseErrorSecurityViolation.txt
+++ b/tests/Omnipay/WorldpayCGHosted/Mock/PurchaseErrorSecurityViolation.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Connection: close
+Server: VPS-3.033.00
+Date: Sat, 23 Feb 2013 05:17:32 GMT
+Content-type: text/xml
+Content-length: 344
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+                                "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MYMERCHANT"><reply><error code="4"><![CDATA[Security violation]]></error></reply></paymentService>

--- a/tests/Omnipay/WorldpayCGHosted/Mock/PurchaseUnauthenticated.txt
+++ b/tests/Omnipay/WorldpayCGHosted/Mock/PurchaseUnauthenticated.txt
@@ -1,0 +1,28 @@
+HTTP/1.1 401 Unauthorized
+Connection: close
+Server: VPS-3.033.00
+Date: Sat, 23 Feb 2013 05:17:32 GMT
+Content-type: text/html
+Content-length: 767
+
+<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <head>
+        <title>401: Requires Authentication</title>
+        <style type="text/css" media="print"> @import url(/pictures/print.css);</style>
+        <style type="text/css" media="screen"> @import url(/pictures/adminstyle-branded.css);</style>
+    </head>
+    <body class="standalone">
+        <div class="content">
+            <span class="legend">Requires Authentication</span>
+            <div class="status">Status: 401</div>
+            <p>
+            This request requires HTTP authentication.
+
+                <br />
+            </p>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
* Fix handling of Error XML responses, correctly pulling through Worldpay's error message & code instead of 'PENDING'.
* Add support for 'username' property, which is optional and distinct from merchant code.
* Test some more realistic error cases, including the non-XML response when a request is unauthenticated.