### PR TITLE
GP-728 - Make billing address optional

### DIFF
--- a/src/Omnipay/WorldpayCGHosted/Message/PurchaseRequest.php
+++ b/src/Omnipay/WorldpayCGHosted/Message/PurchaseRequest.php
@@ -252,7 +252,11 @@ class PurchaseRequest extends AbstractRequest
             $browser->addChild('acceptHeader', $this->getAcceptHeader());
             $browser->addChild('userAgentHeader', $this->getUserAgentHeader());
 
-            if ($this->getCard()) {
+            if ($this->getUseBillingAddress() && (!$this->getCard() || !$this->getCard()->getPostcode())) {
+                throw new InvalidCreditCardException('A billing address is required for this transaction');
+            }
+
+            if ($this->getCard() && $this->getUseBillingAddress()) {
                 $address = $order->addChild('billingAddress')->addChild('address');
                 $address->addChild('firstName', $this->getCard()->getFirstName());
                 $address->addChild('lastName', $this->getCard()->getLastName());
@@ -343,6 +347,22 @@ class PurchaseRequest extends AbstractRequest
     public function setFailureUrl($value)
     {
         return $this->setParameter('failureUrl', $value);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getUseBillingAddress()
+    {
+        return $this->parameters->get('useBillingAddress', true); // default to true
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setUseBillingAddress($enabled)
+    {
+        $this->setParameter('useBillingAddress', $enabled);
     }
 
     /**

--- a/tests/Omnipay/WorldpayCGHosted/GatewayTest.php
+++ b/tests/Omnipay/WorldpayCGHosted/GatewayTest.php
@@ -131,6 +131,27 @@ class GatewayTest extends GatewayTestCase
         $this->assertEquals($this->parameters['notifyUrl'], $purchase->getNotifyUrl());
     }
 
+    /**
+     * Billing address is required with default settings
+     *
+     * @expectedException \Omnipay\Common\Exception\InvalidCreditCardException
+     * @expectedExceptionMessage A billing address is required for this transaction
+     */
+    public function testMissingAddressWithDefaultLogic()
+    {
+        $cardWithoutAddress = new CreditCard([
+            'email' => 'cr+vs@noellh.com',
+        ]);
+
+        $purchase = $this->gateway->purchase($this->parameters);
+        $purchase->setTestMode(true);
+        $purchase->setInstallation('ABC123');
+        $purchase->setMerchant('ACMECO');
+        $purchase->setCard($cardWithoutAddress);
+
+        $purchase->getData();
+    }
+
     public function testAuxiliarySettersAndGetters()
     {
         $this->assertNull($this->gateway->getAcceptHeader());


### PR DESCRIPTION
* Add 'useBillingAddress' PurchaseRequest parameter so transactions can optionally omit an address.
* Explicitly validate postcodes' presence when addresses are in use.