### PR TITLE
Remove instructions about editing composer.json directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,12 @@ multi-gateway payment processing library for PHP 5.6+. This package implements W
 
 ## Installation
 
-Omnipay is installed via [Composer](http://getcomposer.org/). To install, simply
-add it to your `composer.json` file:
+Omnipay is installed via [Composer](http://getcomposer.org/). First, make sure you have composer installed by visiting
+https://getcomposer.org/download/ and following the instructions.
 
-```json
-{
-    "require": {
-        "comicrelief/omnipay-worldpay-cg-hosted": "^1.0.0"
-    }
-}
-```
+Then, install this package by requiring it through composer:
 
-And run composer to update your dependencies:
-
-    $ curl -s http://getcomposer.org/installer | php
-    $ php composer.phar update
+    $ php composer.phar require comicrelief/omnipay-worldpay-cg-hosted
 
 ## Basic Usage
 


### PR DESCRIPTION
Direct people to use command line tool instead.

Editing the composer.json file directly should be avoided where possible, since composer uses a hashed version of the file in composer.lock to determine whether any changes have occurred since the last run or not. Best practice is to _always_ use Composer through the command line where possible to ensure that this hash value is correctly checked and then updated.